### PR TITLE
Flexible crontab generation with settings.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,26 @@ Register tasks with cron
     $ python manage.py installtasks
     Installed 1 task.
 
+You can review the crontab with a ``crontab -l`` command::
+
+    $ crontab -l
+    0 0 * * * /usr/bin/python /path/to/manage.py runtask complain --settings=myprpoject.settings
+
+Usually this line will work pretty well for you, but there can be some rare
+cases when it requires modification. You can achieve it with a number of
+settings variables used by kronos:
+
+* `KRONOS_PYTHON`: python interpreter to build a crontab line. By default the
+                   same interpreter as one you invoked to install tasks is used.
+* `KRONOS_MANAGE`: management command to build a crontab line. By default
+                   ``getcwd() + manage.py`` is used.
+* `KRONOS_PYTHONPATH`: extra path which will be added as a `--pythonpath`
+                       option to management command. By default extra
+                       pythonpath is not used.
+
+Define these variables in your :file:`settings.py` if you wish to alter crontab
+lines.
+
 Installation
 ------------
 

--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -6,7 +6,7 @@ import sys
 from functools import wraps
 
 from kronos.utils import read_crontab, write_crontab, delete_crontab
-from kronos.settings import PROJECT_PATH, PROJECT_MODULE
+from kronos.settings import PROJECT_MODULE, KRONOS_PYTHON, KRONOS_MANAGE, KRONOS_PYTHONPATH
 
 from django.utils.importlib import import_module
 from django.conf import settings
@@ -41,13 +41,15 @@ def register(schedule):
 
         tasks.append(function)
 
-        function.cron_expression = '%(schedule)s %(python)s %(project_path)s/manage.py runtask %(task)s --settings=%(settings_module)s' % {
+        function.cron_expression = '%(schedule)s %(python)s %(manage)s runtask %(task)s --settings=%(settings_module)s' % {
             'schedule': schedule,
-            'python': sys.executable,
-            'project_path': PROJECT_PATH,
+            'python': KRONOS_PYTHON,
+            'manage': KRONOS_MANAGE,
             'task': function.__name__,
             'settings_module': settings.SETTINGS_MODULE,
         }
+        if KRONOS_PYTHONPATH is not None:
+            function.cron_expression += ' --pythonpath=%s' % KRONOS_PYTHONPATH
 
         @wraps(function)
         def wrapper(*args, **kwargs):
@@ -88,9 +90,9 @@ def uninstall():
 
     new_crontab = ''
     for line in current_crontab.split('\n')[:-1]:
-        if '%(python)s %(project_path)s/manage.py runtask' % {
-            'python': sys.executable,
-            'project_path': PROJECT_PATH,
+        if '%(python)s %(manage)s runtask' % {
+            'python': KRONOS_PYTHON,
+            'manage': KRONOS_MANAGE,
         } not in line:
             new_crontab += '%s\n' % line
 

--- a/kronos/settings.py
+++ b/kronos/settings.py
@@ -3,5 +3,7 @@ import sys
 
 from django.conf import settings
 
-PROJECT_PATH = os.getcwd()
+KRONOS_PYTHON = getattr(settings, 'KRONOS_PYTHON', sys.executable)
+KRONOS_MANAGE = getattr(settings, 'KRONOS_MANAGE', '%s/manage.py' % os.getcwd())
+KRONOS_PYTHONPATH = getattr(settings, 'KRONOS_PYTHONPATH', None)
 PROJECT_MODULE = sys.modules['.'.join(settings.SETTINGS_MODULE.split('.')[:-1])]


### PR DESCRIPTION
Hi,

I've addded a bunch of KRONOS_ settings variable to override the way how
crontab line is built.

I suppose there is no harm in this changeset, because it fully maintains backward compatibility while adding some more flexibility to kronos users.

Please consider incorporating this changeset to the upstream, and I would be very grateful if you published a new release with this feature to PyPI. Thank you.
