### PR TITLE
Logging on load function

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,1 +1,2 @@
-Rodrigo N. Carreras (github.com/carrerasrodrigo)
+Rodrigo N. Carreras (https://github.com/carrerasrodrigo)
+Joshua Blum (https://github.com/joshblum)

--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -29,8 +29,9 @@ def load():
     for p in paths:
         try:
             import_module(p)
-        except ImportError:
-            pass
+        except ImportError as e:
+            if e.message != 'No module named cron'
+                print e.message
 
     # load django tasks
     for cmd, app in get_commands().items():

--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -30,7 +30,7 @@ def load():
         try:
             import_module(p)
         except ImportError as e:
-            if e.message != 'No module named cron'
+            if e.message != 'No module named cron':
                 print e.message
 
     # load django tasks


### PR DESCRIPTION
Add a print statement when loading a task fails for a reason other than the cron module not being present. This is helpful for debugging since otherwise install can fail silently