### PR TITLE
Python 3 compatibility fixes

### DIFF
--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -89,13 +89,13 @@ def install():
     Register tasks with cron.
     """
     load()
-    current_crontab = read_crontab()
+    current_crontab = read_crontab().decode()
 
     new_crontab = ''
     for task in tasks:
         new_crontab += '%s\n' % task['fn'].cron_expression
 
-    write_crontab(str(current_crontab) + str(new_crontab))
+    write_crontab(current_crontab + new_crontab)
 
 
 def printtasks():
@@ -116,7 +116,7 @@ def uninstall():
     current_crontab = read_crontab()
 
     new_crontab = ''
-    for line in str(current_crontab).split('\n')[:-1]:
+    for line in current_crontab.decode().split('\n')[:-1]:
         exp = '%(python)s %(manage)s runtask' % {
             'python': KRONOS_PYTHON,
             'manage': KRONOS_MANAGE,

--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -116,7 +116,7 @@ def uninstall():
     current_crontab = read_crontab()
 
     new_crontab = ''
-    for line in current_crontab.split('\n')[:-1]:
+    for line in str(current_crontab).split('\n')[:-1]:
         exp = '%(python)s %(manage)s runtask' % {
             'python': KRONOS_PYTHON,
             'manage': KRONOS_MANAGE,

--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -95,7 +95,7 @@ def install():
     for task in tasks:
         new_crontab += '%s\n' % task['fn'].cron_expression
 
-    write_crontab(current_crontab + new_crontab)
+    write_crontab(str(current_crontab) + str(new_crontab))
 
 
 def printtasks():

--- a/kronos/utils.py
+++ b/kronos/utils.py
@@ -14,7 +14,7 @@ def read_crontab():
 
     stdout, stderr = command.stdout.read(), command.stderr.read()
 
-    if stderr and 'no crontab for' not in str(stderr):
+    if stderr and 'no crontab for' not in stderr.decode():
         raise ValueError('Could not read from crontab: \'%s\'' % stderr)
 
     return stdout
@@ -50,5 +50,5 @@ def delete_crontab():
 
     stdout, stderr = command.stdout.read(), command.stderr.read()
 
-    if stderr and 'no crontab' not in str(stderr):
+    if stderr and 'no crontab' not in stderr.decode():
         raise ValueError('Could not delete crontab: \'%s\'' % stderr)

--- a/kronos/utils.py
+++ b/kronos/utils.py
@@ -14,7 +14,7 @@ def read_crontab():
 
     stdout, stderr = command.stdout.read(), command.stderr.read()
 
-    if stderr and 'no crontab for' not in stderr:
+    if stderr and 'no crontab for' not in str(stderr):
         raise ValueError('Could not read from crontab: \'%s\'' % stderr)
 
     return stdout

--- a/kronos/utils.py
+++ b/kronos/utils.py
@@ -50,5 +50,5 @@ def delete_crontab():
 
     stdout, stderr = command.stdout.read(), command.stderr.read()
 
-    if stderr and 'no crontab' not in stderr:
+    if stderr and 'no crontab' not in str(stderr):
         raise ValueError('Could not delete crontab: \'%s\'' % stderr)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup
 
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
-execfile('kronos/version.py')
+exec(compile(open('kronos/version.py').read(), 'kronos/version.py', 'exec'))
 
 readme = open('README.rst').read()
 history = open('HISTORY.rst').read()


### PR DESCRIPTION
These changes fix some Python 3 compatibility issues, while still supporting Python 2 (tested so far in only 2.7.6 and 3.4.0).

Changes:
 - Replace deprecated execfile() command with what should be a Python 2.x and 3.x compatible solution
 - Decode stdout and stderr before performing string operations, since Python 3 is more strict about the type operations.

Let me know how this looks and if you can think of any issues.