### PR TITLE
add try/except block around loading commands

### DIFF
--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -1,5 +1,6 @@
 from functools import wraps
 
+import django
 from django.core.management import get_commands, load_command_class
 from django.utils.importlib import import_module
 from kronos.settings import PROJECT_MODULE, KRONOS_PYTHON, KRONOS_MANAGE, \
@@ -35,7 +36,10 @@ def load():
 
     # load django tasks
     for cmd, app in get_commands().items():
-        load_command_class(app, cmd)
+        try:
+            load_command_class(app, cmd)
+        except django.core.exceptions.ImproperlyConfigured:
+            pass
 
 
 def register(schedule):


### PR DESCRIPTION
Some apps don't play nice with django 1.7 and on `load_command_class(app, cmd)` raise

```
django.core.exceptions.ImproperlyConfigured: 
Command Command defines both "requires_model_validation" and 
"requires_system_checks", which is illegal. 
Use only "requires_system_checks".
```

This causes kronos to fail on most (probably every) command, small try/except block prevents this.
