### PR TITLE
Make logging message compatible with python 3

### DIFF
--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -31,7 +31,7 @@ def load():
             import_module(p)
         except ImportError as e:
             if e.message != 'No module named cron':
-                print e.message
+                print(e.message)
 
     # load django tasks
     for cmd, app in get_commands().items():


### PR DESCRIPTION
My fault for not using the `print` function with this fix. Address #30.