### PR TITLE
Use Python's importlib if it exists

### DIFF
--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -2,7 +2,12 @@ from functools import wraps
 
 import django
 from django.core.management import get_commands, load_command_class
-from django.utils.importlib import import_module
+
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
+
 from kronos.settings import PROJECT_MODULE, KRONOS_PYTHON, KRONOS_MANAGE, \
     KRONOS_PYTHONPATH, KRONOS_POSTFIX
 from django.conf import settings


### PR DESCRIPTION
Attempted use of django.utils.importlib generates a warning in Django 1.8 - this module will be removed in 1.9.

https://docs.djangoproject.com/en/1.8/releases/1.7/#django-utils-dictconfig-django-utils-importlib