### PR TITLE
cron load module discovery fix

### DIFF
--- a/kronos/settings.py
+++ b/kronos/settings.py
@@ -6,6 +6,9 @@ from django.conf import settings
 KRONOS_PYTHON = getattr(settings, 'KRONOS_PYTHON', sys.executable)
 KRONOS_MANAGE = getattr(settings, 'KRONOS_MANAGE', '%s/manage.py' % os.getcwd())
 KRONOS_PYTHONPATH = getattr(settings, 'KRONOS_PYTHONPATH', None)
-PROJECT_MODULE = sys.modules['.'.join(settings.SETTINGS_MODULE.split('.')[:-1])]
+try:
+    PROJECT_MODULE = sys.modules['.'.join(settings.SETTINGS_MODULE.split('.')[:-1])]
+except KeyError:
+    PROJECT_MODULE = None
 KRONOS_POSTFIX = getattr(settings, 'KRONOS_POSTFIX', '')
 KRONOS_PREFIX = getattr(settings, 'KRONOS_PREFIX', '')


### PR DESCRIPTION
I still have some problem so I reopen a pull request based on the latest version

The PROJECT_MODULE calculation in settings is causing KeyError for me. autodiscover_modules is probably a good solution but not available on Django 1.6.

What I did was to perform the old cron module discovery if autodiscover_modules is not available and If a KeyError appens, PROJECT_MODULE is set to None