### PR TITLE
Argument length checking

### DIFF
--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -62,19 +62,17 @@ def process_args(args):
         if isinstance(value, dict):
             raise TypeError('Parse for dict arguments not yet implemented.')
 
-        separator = " " if len(key.lstrip("-")) == 1 else "="
-
         if isinstance(value, list):
             temp_args = ",".join(map(str, value))
-            res.append("{}{}".format(key + separator, temp_args))
+            res.append("{} {}".format(key, temp_args))
         else:
             if value is None:
                 arg_text = "{}"
             elif isinstance(value, str):
-                arg_text = '{}"{}"'
+                arg_text = '{} "{}"'
             else:
-                arg_text = '{}{}'
-            res.append(arg_text.format(key + separator, value))
+                arg_text = '{} {}'
+            res.append(arg_text.format(key, value))
     return res
 
 

--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -62,17 +62,19 @@ def process_args(args):
         if isinstance(value, dict):
             raise TypeError('Parse for dict arguments not yet implemented.')
 
+        separator = " " if len(key.lstrip("-")) == 1 else "="
+
         if isinstance(value, list):
             temp_args = ",".join(map(str, value))
-            res.append("{}={}".format(key, temp_args))
+            res.append("{}{}".format(key + separator, temp_args))
         else:
             if value is None:
                 arg_text = "{}"
             elif isinstance(value, str):
-                arg_text = '{}="{}"'
+                arg_text = '{}"{}"'
             else:
-                arg_text = '{}={}'
-            res.append(arg_text.format(key, value))
+                arg_text = '{}{}'
+            res.append(arg_text.format(key + separator, value))
     return res
 
 


### PR DESCRIPTION
For each key-value command line argument pair, the key can be:

A) one char length (like -a, -C, -T, etc):
    in this case, the pair is separated by a space char (' '), like

```
python manage.py <command> -a <value>
```

B) multiple char length (like --batch, --limit, etc):
    if so, the pair has to be glued by '=' char, like

```
python manage.py <command> --batch=<value>
```

Given that, one should check for the key length and apply the respective
formatting.
