### PR TITLE
Add coveralls and fix readme badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 *.pyc
 dist
 django_kronos.egg-info
+.coverage

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,13 @@
 .. image::  https://raw.githubusercontent.com/jgorset/django-kronos/master/docs/banner.png
 
-.. image:: https://api.travis-ci.org/jgorset/django-kronos.svg?branch=master
+.. image:: https://coveralls.io/repos/github/joshblum/django-kronos/badge.svg?branch=master
+    :target: https://coveralls.io/github/joshblum/django-kronos?branch=master
+.. image:: https://travis-ci.org/jgorset/django-kronos.svg?branch=master
+    :target: https://travis-ci.org/jgorset/django-kronos
 .. image:: https://img.shields.io/github/license/jgorset/django-kronos.svg
+    :target: https://raw.githubusercontent.com/jgorset/django-kronos/master/LICENSE
 .. image:: https://img.shields.io/pypi/v/django-kronos.svg
+    :target: https://pypi.python.org/pypi/django-kronos/
 
 Usage
 -----

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,13 @@
 envlist = {django17,django18,django19}-{py27,py33,py34}
 
 [testenv]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps = mock
+    coveralls
     django17: django>=1.7,<1.8
     django18: django>=1.8,<1.9
     django19: django>=1.9
 commands =
     python setup.py develop
-    python manage.py test
+    coverage run --source=kronos manage.py test
+    coveralls


### PR DESCRIPTION
Just a suggestion, the coveralls badge is nice to have to keep track of test coverage however and also I feel it gives people more confidence when choosing a project if the coverage is high.