### PR TITLE
Added Django 1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: python
 env:
-    - TOXENV=django17-py27
     - TOXENV=django18-py27
     - TOXENV=django19-py27
     - TOXENV=django110-py27
-    - TOXENV=django17-py33
     - TOXENV=django18-py33
-    - TOXENV=django17-py34
     - TOXENV=django18-py34
     - TOXENV=django19-py34
     - TOXENV=django110-py34

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ env:
     - TOXENV=django17-py34
     - TOXENV=django18-py34
     - TOXENV=django19-py34
+    - TOXENV=django110-py34
+    - TOXENV=django18-py35
+    - TOXENV=django19-py35
+    - TOXENV=django110-py35
 install:
     - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env:
     - TOXENV=django17-py27
     - TOXENV=django18-py27
     - TOXENV=django19-py27
+    - TOXENV=django110-py27
     - TOXENV=django17-py33
     - TOXENV=django18-py33
     - TOXENV=django17-py34

--- a/README.rst
+++ b/README.rst
@@ -35,13 +35,13 @@ Kronos works with Django management commands, too::
 
     # app/management/commands/task.py
 
-    from django.core.management.base import NoArgsCommand
+    from django.core.management.base import BaseCommand
 
     import kronos
 
     @kronos.register('0 0 * * *')
-    class Command(NoArgsCommand):
-        def handle_noargs(self, **options):
+    class Command(BaseCommand):
+        def handle(self, **options):
             print('Hello, world!')
 
 If your management command accepts arguments, just pass them in the decorator::

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Kronos works with Django management commands, too::
 
     @kronos.register('0 0 * * *')
     class Command(BaseCommand):
-        def handle(self, **options):
+        def handle(self, *args, **options):
             print('Hello, world!')
 
 If your management command accepts arguments, just pass them in the decorator::
@@ -55,12 +55,13 @@ If your management command accepts arguments, just pass them in the decorator::
     @kronos.register('0 0 * * *', args={'-l': 'nb'})
     class Command(BaseCommand):
 
-        option_list = BaseCommand.option_list + (
-          make_option('-l', '--language',
-            dest    = 'language',
-            type    = 'string',
-            default = 'en')
-        )
+        def add_arguments(self, parser):
+            parser.add_argument(
+                '-l', '--language',
+                dest='language',
+                type=str,
+                default='en',
+            )
 
         def handle(self, *args, **options):
             if options['language'] == 'en':

--- a/kronos/management/commands/installtasks.py
+++ b/kronos/management/commands/installtasks.py
@@ -1,11 +1,11 @@
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 from kronos import reinstall
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = 'Register tasks with cron'
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         removed, installed = reinstall()
         if not removed:
             print("{} tasks installed.".format(installed))

--- a/kronos/management/commands/installtasks.py
+++ b/kronos/management/commands/installtasks.py
@@ -5,7 +5,7 @@ from kronos import reinstall
 class Command(BaseCommand):
     help = 'Register tasks with cron'
 
-    def handle(self, **options):
+    def handle(self, *args, **options):
         removed, installed = reinstall()
         if not removed:
             print("{} tasks installed.".format(installed))

--- a/kronos/management/commands/runtask.py
+++ b/kronos/management/commands/runtask.py
@@ -4,13 +4,12 @@ from django.core.management.base import BaseCommand, CommandError
 
 
 class Command(BaseCommand):
-    args = '<task>'
     help = 'Run the given task'
 
     def add_arguments(self, parser):
         parser.add_argument('task', nargs='?', type=str)
 
-    def handle(self, **options):
+    def handle(self, *args, **options):
         kronos.load()
 
         task_name = options.get('task')

--- a/kronos/management/commands/runtask.py
+++ b/kronos/management/commands/runtask.py
@@ -7,8 +7,13 @@ class Command(BaseCommand):
     args = '<task>'
     help = 'Run the given task'
 
-    def handle(self, task_name, **options):
+    def add_arguments(self, parser):
+        parser.add_argument('task', nargs='?', type=str)
+
+    def handle(self, **options):
         kronos.load()
+
+        task_name = options.get('task')
 
         for task in kronos.registry:
             if task.name == task_name:

--- a/kronos/management/commands/uninstalltasks.py
+++ b/kronos/management/commands/uninstalltasks.py
@@ -6,6 +6,6 @@ from kronos import uninstall
 class Command(BaseCommand):
     help = 'Remove tasks from cron'
 
-    def handle(self, **options):
+    def handle(self, *args, **options):
         count = uninstall()
         print('{} tasks removed'.format(count))

--- a/kronos/management/commands/uninstalltasks.py
+++ b/kronos/management/commands/uninstalltasks.py
@@ -1,11 +1,11 @@
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from kronos import uninstall
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = 'Remove tasks from cron'
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         count = uninstall()
         print('{} tasks removed'.format(count))

--- a/kronos/tests/project/app/management/commands/task.py
+++ b/kronos/tests/project/app/management/commands/task.py
@@ -1,11 +1,11 @@
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 import kronos
 
 
 @kronos.register('0 0 * * *')
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = 'Register tasks with cron'
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         print('command task')

--- a/kronos/tests/project/app/management/commands/task.py
+++ b/kronos/tests/project/app/management/commands/task.py
@@ -7,5 +7,5 @@ import kronos
 class Command(BaseCommand):
     help = 'Register tasks with cron'
 
-    def handle(self, **options):
+    def handle(self, *args, **options):
         print('command task')

--- a/kronos/tests/project/app/management/commands/task_with_args.py
+++ b/kronos/tests/project/app/management/commands/task_with_args.py
@@ -1,11 +1,11 @@
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 import kronos
 
 
 @kronos.register('0 0 * * *', args={"--arg1": None, "-b": "some-arg2", "--some-list": ["site1", "site2", "site3"]})
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = 'Register tasks with cron'
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         print('command task')

--- a/kronos/tests/project/app/management/commands/task_with_args.py
+++ b/kronos/tests/project/app/management/commands/task_with_args.py
@@ -7,5 +7,5 @@ import kronos
 class Command(BaseCommand):
     help = 'Register tasks with cron'
 
-    def handle(self, **options):
+    def handle(self, *args, **options):
         print('command task')

--- a/kronos/tests/project/app/management/commands/task_with_empty_args.py
+++ b/kronos/tests/project/app/management/commands/task_with_empty_args.py
@@ -1,11 +1,11 @@
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 import kronos
 
 
 @kronos.register('0 0 * * *', args={})
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = 'Register tasks with cron'
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         print('command task')

--- a/kronos/tests/project/app/management/commands/task_with_empty_args.py
+++ b/kronos/tests/project/app/management/commands/task_with_empty_args.py
@@ -7,5 +7,5 @@ import kronos
 class Command(BaseCommand):
     help = 'Register tasks with cron'
 
-    def handle(self, **options):
+    def handle(self, *args, **options):
         print('command task')

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = {django17,django18,django19,django110}-{py27,py33,py34,py35}
+envlist = {django18,django19,django110}-{py27,py33,py34,py35}
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps = mock
     coveralls
-    django17: django>=1.7,<1.8
     django18: django>=1.8,<1.9
     django19: django>=1.9,<1.10
     django110: django>=1.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {django17,django18,django19}-{py27,py33,py34}
+envlist = {django17,django18,django19,django110}-{py27,py33,py34,py35}
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
@@ -7,7 +7,8 @@ deps = mock
     coveralls
     django17: django>=1.7,<1.8
     django18: django>=1.8,<1.9
-    django19: django>=1.9
+    django19: django>=1.9,<1.10
+    django110: django>=1.10
 commands =
     python setup.py develop
     coverage run --source=kronos manage.py test


### PR DESCRIPTION
As discussed in #53, `NoArgsCommand` is deprecated in Django 1.10 which makes `django-kronos` unusable. Fortunately the fix is easy (via [docs][django docs]):

```
class NoArgsCommand
    Deprecated since version 1.8:
    Use BaseCommand instead, which takes no arguments by default.
```

I also added Django 1.10 and Python 3.5 to testing config (both `tox.ini` and `travis.yml`).

[django docs]: https://docs.djangoproject.com/en/1.9/howto/custom-management-commands/#django.core.management.NoArgsCommand