### PR TITLE
Allow different cron jobs per server (settings file)

### DIFF
--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -104,7 +104,7 @@ def register(schedule, args=None, settings_filter=None):
         if KRONOS_PYTHONPATH is not None:
             command += ' --pythonpath=%s' % KRONOS_PYTHONPATH
 
-        if settings_filter is None or getattr(django.conf.settings, settings_filter, True):
+        if settings_filter is None or getattr(django.conf.settings, settings_filter, False):
             registry.add(Task(name, schedule, command, func))
 
         @wraps(function)

--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -104,7 +104,7 @@ def register(schedule, args=None, settings_filter=None):
         if KRONOS_PYTHONPATH is not None:
             command += ' --pythonpath=%s' % KRONOS_PYTHONPATH
 
-        if settings_filter is not None and getattr(django.conf.settings, settings_filter, True):
+        if settings_filter is None or getattr(django.conf.settings, settings_filter, True):
             registry.add(Task(name, schedule, command, func))
 
         @wraps(function)

--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -104,7 +104,7 @@ def register(schedule, args=None, settings_filter=None):
         if KRONOS_PYTHONPATH is not None:
             command += ' --pythonpath=%s' % KRONOS_PYTHONPATH
 
-        if getattr(conf.settings, settings_filter, True):
+        if getattr(django.conf.settings, settings_filter, True):
             registry.add(Task(name, schedule, command, func))
 
         @wraps(function)

--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -76,7 +76,7 @@ def process_args(args):
     return res
 
 
-def register(schedule, args=None):
+def register(schedule, args=None, settings_filter=None):
     def decorator(function):
         global registry_kronos, registry_django
 
@@ -104,7 +104,8 @@ def register(schedule, args=None):
         if KRONOS_PYTHONPATH is not None:
             command += ' --pythonpath=%s' % KRONOS_PYTHONPATH
 
-        registry.add(Task(name, schedule, command, func))
+        if getattr(conf.settings, settings_filter, True):
+            registry.add(Task(name, schedule, command, func))
 
         @wraps(function)
         def wrapper(*args, **kwargs):

--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -104,7 +104,7 @@ def register(schedule, args=None, settings_filter=None):
         if KRONOS_PYTHONPATH is not None:
             command += ' --pythonpath=%s' % KRONOS_PYTHONPATH
 
-        if getattr(django.conf.settings, settings_filter, True):
+        if settings_filter is not None and getattr(django.conf.settings, settings_filter, True):
             registry.add(Task(name, schedule, command, func))
 
         @wraps(function)


### PR DESCRIPTION
We have different servers running with different purposes, so we'd like to run certain cron jobs on specific servers. 

Here's an example call:
@kronos.register('*/2 * * * *', args={'-c': 'combo'}, settings_filter='PUSH_ENABLED')
...

Where the settings file for a server has:
PUSH_ENABLED = True


