### PR TITLE
fix: Fix python-crontab dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mock
 django==1.7
 six==1.9.0
-python-crontab>=1.9
+python-crontab>=1.9,<=2.6.0


### PR DESCRIPTION
python-crontab > 2.6 does not support Python 2.7 anymore

<img width="1049" alt="Screenshot 2023-02-09 at 11 17 00" src="https://user-images.githubusercontent.com/2766648/217798177-8be17b22-4b46-42a5-b514-b5d6ce85e925.png">
